### PR TITLE
Add inline editing for committee members

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -475,6 +475,53 @@
         ::-webkit-scrollbar-thumb:hover {
             background: #666;
         }
+
+        /* Styles for new elements */
+        .nav-button { /* For Login button */
+            background: #f3f3f3;
+            color: #181a1b;
+            padding: 10px 20px;
+            border-radius: 25px;
+            font-weight: 500;
+            border: none;
+            cursor: pointer;
+            transition: background 0.2s, color 0.2s;
+        }
+
+        .nav-button:hover {
+            background: #4fc3f7;
+            color: #181a1b;
+        }
+
+        .edit-icon {
+            cursor: pointer;
+            font-size: 1.2em; /* Adjust as needed */
+            margin-left: 10px;
+            display: inline-block; /* Allows margin and proper display */
+        }
+
+        .confirm-btn {
+            background: #4CAF50; /* Green */
+            color: white;
+            padding: 8px 15px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            margin-top: 10px;
+            display: block; /* Or inline-block if preferred next to text */
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .confirm-btn:hover {
+            background: #45a049;
+        }
+
+        .editable-active {
+            outline: 1px dashed #4fc3f7; /* Light blue dashed outline */
+            background-color: rgba(79, 195, 247, 0.1); /* Light blue semi-transparent background */
+            padding: 2px;
+        }
     </style>
     <!-- ...existing code... -->
 </head>
@@ -496,6 +543,7 @@
                 <li><a href="#committee">Committee</a></li>
                 <li><a href="#events">Events</a></li>
                 <li><a href="#articles">Articles</a></li>
+                <li><button id="loginBtn" class="nav-button">Login</button></li>
             </ul>
         </nav>
     </header>
@@ -553,39 +601,51 @@
             <div class="committee-grid">
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">AJ</div>
-                    <h3>Alex John</h3>
-                    <p><strong>President</strong></p>
-                    <p>Leading our organization with vision and dedication to youth empowerment.</p>
+                    <h3 class="member-name" contenteditable="false">Alex John</h3>
+                    <p><strong class="member-designation" contenteditable="false">President</strong></p>
+                    <p class="member-description" contenteditable="false">Leading our organization with vision and dedication to youth empowerment.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">SM</div>
-                    <h3>Sarah Matthew</h3>
-                    <p><strong>Vice President</strong></p>
-                    <p>Supporting leadership initiatives and community outreach programs.</p>
+                    <h3 class="member-name" contenteditable="false">Sarah Matthew</h3>
+                    <p><strong class="member-designation" contenteditable="false">Vice President</strong></p>
+                    <p class="member-description" contenteditable="false">Supporting leadership initiatives and community outreach programs.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">DJ</div>
-                    <h3>David Joseph</h3>
-                    <p><strong>Secretary</strong></p>
-                    <p>Managing organizational communications and documentation.</p>
+                    <h3 class="member-name" contenteditable="false">David Joseph</h3>
+                    <p><strong class="member-designation" contenteditable="false">Secretary</strong></p>
+                    <p class="member-description" contenteditable="false">Managing organizational communications and documentation.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">RT</div>
-                    <h3>Rachel Thomas</h3>
-                    <p><strong>Treasurer</strong></p>
-                    <p>Overseeing financial management and resource allocation.</p>
+                    <h3 class="member-name" contenteditable="false">Rachel Thomas</h3>
+                    <p><strong class="member-designation" contenteditable="false">Treasurer</strong></p>
+                    <p class="member-description" contenteditable="false">Overseeing financial management and resource allocation.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">MG</div>
-                    <h3>Mark George</h3>
-                    <p><strong>Program Coordinator</strong></p>
-                    <p>Organizing events and coordinating youth activities.</p>
+                    <h3 class="member-name" contenteditable="false">Mark George</h3>
+                    <p><strong class="member-designation" contenteditable="false">Program Coordinator</strong></p>
+                    <p class="member-description" contenteditable="false">Organizing events and coordinating youth activities.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
                 <div class="member-card animate-on-scroll">
                     <div class="member-avatar">LV</div>
-                    <h3>Liya Varghese</h3>
-                    <p><strong>Outreach Director</strong></p>
-                    <p>Leading community service and social impact initiatives.</p>
+                    <h3 class="member-name" contenteditable="false">Liya Varghese</h3>
+                    <p><strong class="member-designation" contenteditable="false">Outreach Director</strong></p>
+                    <p class="member-description" contenteditable="false">Leading community service and social impact initiatives.</p>
+                    <span class="edit-icon" style="display:none;">&#9998;</span>
+                    <button class="confirm-btn" style="display:none;">Confirm</button>
                 </div>
             </div>
         </div>
@@ -908,6 +968,96 @@
                 heroBg.style.opacity = 1;
             }, 1000); // match CSS transition duration
         }, 5000);
+
+        // --------- NEW SCRIPT FOR EDIT FUNCTIONALITY START ---------
+        let isLoggedIn = false;
+        const loginBtn = document.getElementById('loginBtn');
+        const committeeGrid = document.querySelector('.committee-grid');
+        const memberCards = document.querySelectorAll('.member-card');
+
+        loginBtn.addEventListener('click', () => {
+            isLoggedIn = !isLoggedIn;
+            loginBtn.textContent = isLoggedIn ? 'Logout' : 'Login';
+
+            memberCards.forEach(card => {
+                const editIcon = card.querySelector('.edit-icon');
+                const confirmBtn = card.querySelector('.confirm-btn');
+                const nameField = card.querySelector('.member-name');
+                const designationField = card.querySelector('.member-designation');
+                const descriptionField = card.querySelector('.member-description');
+
+                if (isLoggedIn) {
+                    editIcon.style.display = 'inline-block'; // Show edit icon
+                    confirmBtn.style.display = 'none'; // Ensure confirm is hidden
+                    // Ensure fields are not editable by default on login, only when edit icon is clicked
+                    nameField.contentEditable = 'false';
+                    designationField.contentEditable = 'false';
+                    descriptionField.contentEditable = 'false';
+                    nameField.classList.remove('editable-active');
+                    designationField.classList.remove('editable-active');
+                    descriptionField.classList.remove('editable-active');
+                } else {
+                    // Logout: hide icons, make non-editable, remove active class
+                    editIcon.style.display = 'none';
+                    confirmBtn.style.display = 'none';
+                    nameField.contentEditable = 'false';
+                    designationField.contentEditable = 'false';
+                    descriptionField.contentEditable = 'false';
+                    nameField.classList.remove('editable-active');
+                    designationField.classList.remove('editable-active');
+                    descriptionField.classList.remove('editable-active');
+                }
+            });
+        });
+
+        committeeGrid.addEventListener('click', (event) => {
+            if (!isLoggedIn) return; // Only allow edits if logged in
+
+            const target = event.target;
+
+            if (target.classList.contains('edit-icon')) {
+                const card = target.closest('.member-card');
+                const nameField = card.querySelector('.member-name');
+                const designationField = card.querySelector('.member-designation');
+                const descriptionField = card.querySelector('.member-description');
+                const confirmBtn = card.querySelector('.confirm-btn');
+
+                nameField.contentEditable = 'true';
+                designationField.contentEditable = 'true';
+                descriptionField.contentEditable = 'true';
+
+                nameField.classList.add('editable-active');
+                designationField.classList.add('editable-active');
+                descriptionField.classList.add('editable-active');
+
+                target.style.display = 'none'; // Hide edit icon
+                confirmBtn.style.display = 'block'; // Show confirm button
+                nameField.focus(); // Focus on the first editable field
+            }
+
+            if (target.classList.contains('confirm-btn')) {
+                const card = target.closest('.member-card');
+                const nameField = card.querySelector('.member-name');
+                const designationField = card.querySelector('.member-designation');
+                const descriptionField = card.querySelector('.member-description');
+                const editIcon = card.querySelector('.edit-icon');
+
+                nameField.contentEditable = 'false';
+                designationField.contentEditable = 'false';
+                descriptionField.contentEditable = 'false';
+
+                nameField.classList.remove('editable-active');
+                designationField.classList.remove('editable-active');
+                descriptionField.classList.remove('editable-active');
+
+                target.style.display = 'none'; // Hide confirm button
+                editIcon.style.display = 'inline-block'; // Show edit icon
+
+                // Placeholder: In a real app, you would send the updated data to a server here.
+                console.log(`Changes for ${nameField.textContent} confirmed locally.`);
+            }
+        });
+        // --------- NEW SCRIPT FOR EDIT FUNCTIONALITY END -----------
     </script>
 </body>
 


### PR DESCRIPTION
- Added a Login/Logout button to the navbar.
- When logged in, an edit icon appears on each committee member card.
- Clicking the edit icon allows inline editing of the member's name, designation, and description.
- A 'Confirm' button saves the changes (currently local, console log).
- Logging out disables editing and hides edit controls.
- Styling added for new buttons, icons, and editable state.